### PR TITLE
Delete sed when ELASTICSEARCH_USER and PASSWORD are defined

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -90,10 +90,7 @@ else
     fi
 fi
 
-if [ "$ELASTICSEARCH_USER" != "" -a "$ELASTICSEARCH_PASSWORD" != "" ]; then
-    sed -e "s|^elasticsearch.username:.*$|elasticsearch.username: \"$ELASTICSEARCH_USER\"|" -i /opt/kibana/config/kibana.yml
-    sed -e "s|^elasticsearch.password:.*$|elasticsearch.password: \"$ELASTICSEARCH_PASSWORD\"|" -i /opt/kibana/config/kibana.yml
-else
+if [ -z "$ELASTICSEARCH_USER" ] || [ -z "$ELASTICSEARCH_PASSWORD" ]; then
     echo >&2 'error: ELASTICSEARCH_USER or/and ELASTICSEARCH_PASSWORD environment variables were not configured'
     echo >&2 '  these two docker environment variables must be configured before running the container'
     exit 1


### PR DESCRIPTION
This commit deletes the sed in the kibana.yml file when the
variables are defined because the functionality is already included
in the OD image and produce errors in Bitergia's deploys.